### PR TITLE
httpS для авторизации

### DIFF
--- a/startSettings/settings.ini
+++ b/startSettings/settings.ini
@@ -4,8 +4,8 @@ notify=false
 
 [servers]
 development=http://app.metahash.org/api-dev/
-production=http://app.metahash.org/api/
-auth=http://id.metahash.org/api/
+production=https://app.metahash.org/api/
+auth=https://id.metahash.org/api/
 
 [downloader]
 period_sec=300
@@ -15,7 +15,7 @@ meta_online=wss://ws.metahash.io/
 messenger=wss://messenger.metahash.io
 
 [dns]
-metahash=http://app.metahash.io/api/dns/
+metahash=https://app.metahash.io/api/dns/
 net=dev
 
 [nodes]


### PR DESCRIPTION
Сейчас параметры авторизации передаются в открытом виде по незащищённому каналу. В мобильном приложении авторизация идёт уже по `правильному` httpS: https://github.com/metahashorg/MetaWallet-iOS/blob/c8a8110c08f08f899a1a7360ea2807d96a2f455a/metawallet/HostProvider.swift#L25